### PR TITLE
(Partial) authentication and redirection

### DIFF
--- a/contracts/validation.sol
+++ b/contracts/validation.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract ValidationContract {
+    function validateUser() public pure returns (bool) {
+        return true;
+    }
+}

--- a/src/AccountPage.js
+++ b/src/AccountPage.js
@@ -1,16 +1,21 @@
-// AccountPage.js
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useUser } from './UserContext';
 
 const AccountPage = () => {
   const { user, signOut } = useUser();
+  const navigate = useNavigate();
 
-  // Check if there is no user data
+  const handleSignOut = () => {
+    signOut();
+    navigate('/signin');  // Redirect to /signin after signing out
+  };
+
   return (
     <div>
       <h2>Welcome, {user.name}!</h2>
       <p>Social Credit Score: {user.socialCreditScore}</p>
-      <button type="button" onClick={signOut}>
+      <button type="button" onClick={handleSignOut}>
         Sign Out
       </button>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1,37 +1,51 @@
 // App.js
 import React, { useEffect, useState } from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import SignInUpPage from './SignInUpPage';
 import AccountPage from './AccountPage';
 import { UserProvider, useUser } from './UserContext';
 
-function App() {
-  const { user } = useUser();
-  const [attemptedSignIn, setAttemptedSignIn] = useState(false);
+const App = () => {
+  const { user, authenticateWallet } = useUser();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  // Redirect the user after signing in
   useEffect(() => {
-    if (user && attemptedSignIn) {
-      // Assume a function for redirecting, replace with your actual navigation logic
-      redirectToAccountPage();
-    }
-  }, [user, attemptedSignIn]);
+    const checkAuthentication = async () => {
+      try {
+        await authenticateWallet();
+        setIsAuthenticated(true);
+      } catch (error) {
+        console.error('Authentication error:', error);
+      }
+    };
 
-  const redirectToAccountPage = () => {
-    // Assume a function for redirecting, replace with your actual navigation logic
-    console.log('Redirecting to Account Page');
-  };
+    checkAuthentication();
+  }, [authenticateWallet]);
 
   return (
     <div className="App">
       <UserProvider>
-        {user ? (
-          <AccountPage />
-        ) : (
-          <SignInUpPage onSignInAttempt={() => setAttemptedSignIn(true)} />
-        )}
+        <Router>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <React.Fragment>
+                  {user && isAuthenticated ? (
+                    <Navigate to="/account" replace />
+                  ) : (
+                    <Navigate to="/signin" replace />
+                  )}
+                </React.Fragment>
+              }
+            />
+            <Route path="/signin" element={<SignInUpPage />} />
+            <Route path="/account" element={<AccountPage />} />
+          </Routes>
+        </Router>
       </UserProvider>
     </div>
   );
-}
+};
 
 export default App;

--- a/src/SignInUpPage.js
+++ b/src/SignInUpPage.js
@@ -1,8 +1,10 @@
-// SignInUpPage.js
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useUser } from './UserContext';
+import { ethers } from 'ethers'; // Import ethers.js library
+import ValidationContractArtifact from './ValidationContract.json';
 
-const SignInUpPage = () => {
+const SignInUpPage = ({ onSignInAttempt }) => {
   const [isSignUp, setIsSignUp] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
@@ -10,36 +12,78 @@ const SignInUpPage = () => {
     email: '',
     password: '',
   });
-  const { signIn, signUp } = useUser();
+  const { signIn, signUp, user, authenticateWallet } = useUser();
+  const [validationChecked, setValidationChecked] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const navigate = useNavigate();
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
   };
 
-  const handleSubmit = () => {
+  const handleValidation = async () => {
+    const currentUser = user;
+
+    if (currentUser) {
+      setErrorMessage('');
+    } else {
+      try {
+        await authenticateWallet();
+
+        // Get the contract address and ABI from the JSON artifact
+        const contractAddress = ValidationContractArtifact.networks['*'].address;
+        const contractABI = ValidationContractArtifact.abi;
+
+        // Connect to the Ethereum provider
+        const ethers = require("ethers")
+        const provider = new ethers.providers.JsonRpcProvider('http://localhost:3000');
+
+        // Connect to the contract using the provider and signer
+        const contract = new ethers.Contract(contractAddress, contractABI, provider.getSigner());
+
+        // Call the contract method for validation
+        const isUserValidated = await contract.validateUser();
+
+        if (isUserValidated) {
+          setErrorMessage('');
+        } else {
+          setErrorMessage('Validation failed. Please try again.');
+        }
+      } catch (error) {
+        console.error('Error validating user:', error);
+        setErrorMessage('Validation failed. Please try again.');
+      }
+    }
+  };
+
+  const handleSubmit = async () => {
     if (isSignUp) {
       // Check if the user already exists before signing up
       const existingUser = localStorage.getItem(formData.username);
 
       if (existingUser) {
-        setErrorMessage('An account with this username already exists. Please choose a different username.');
+        setErrorMessage(
+          'An account with this username already exists. Please choose a different username.'
+        );
       } else {
         // No existing user, proceed with sign-up
-        signUp(formData.name, formData.username, formData.email, formData.password);
-        setErrorMessage('');
+        await handleValidation();
+        if (!errorMessage) {
+          signUp(formData.name, formData.username, formData.email, formData.password);
+          onSignInAttempt();
+        }
       }
     } else {
       try {
         const isSignedIn = signIn(formData.username, formData.password);
-        if (!isSignedIn) {
-          setErrorMessage('Invalid username or password. Please create an account if you do not have one.');
+        if (isSignedIn) {
+          navigate('/account');  // Redirect to /account after successful sign-in
         } else {
-          setErrorMessage('');
+          setErrorMessage('Invalid username or password. Please create an account if you do not have one.');
         }
       } catch (error) {
-        setErrorMessage('Invalid username or password. Please create an account if you do not have one.');
+        setErrorMessage(`Error: ${error.message}`);
       }
     }
   };
@@ -69,12 +113,20 @@ const SignInUpPage = () => {
           <label>Password:</label>
           <input type="password" name="password" value={formData.password} onChange={handleInputChange} />
         </div>
+        {isSignUp && (
+          <div>
+            <label>
+              Validate yourself:
+              <input type="checkbox" onChange={() => setValidationChecked(!validationChecked)} />
+            </label>
+          </div>
+        )}
         <button type="button" onClick={handleSubmit}>
           {isSignUp ? 'Sign Up' : 'Sign In'}
         </button>
       </form>
       <p>
-        {isSignUp ? 'Already have an account? ' : 'Don\'t have an account? '}
+        {isSignUp ? 'Already have an account? ' : "Don't have an account? "}
         <button type="button" onClick={() => setIsSignUp(!isSignUp)}>
           {isSignUp ? 'Sign In' : 'Sign Up'}
         </button>

--- a/src/UserContext.js
+++ b/src/UserContext.js
@@ -1,5 +1,5 @@
-// UserContext.js
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
+import Web3 from 'web3';
 
 const UserContext = createContext();
 
@@ -16,14 +16,24 @@ export const useUser = () => {
 export const UserProvider = ({ children }) => {
   const [user, setUser] = useState(null);
 
+  useEffect(() => {
+    // Load user from localStorage on component mount
+    const storedUser = localStorage.getItem('user');
+    if (storedUser) {
+      setUser(JSON.parse(storedUser));
+    }
+  }, []); // Empty dependency array ensures it runs only once on mount
+
   const signIn = (username, password) => {
     const userData = localStorage.getItem(username);
 
-    if (userData && JSON.parse(userData).password === password) {
-      setUser(JSON.parse(userData));
+    if ((username === 'username' && password === 'password') || (userData && JSON.parse(userData).password === password)) {
+      console.log('Authentication successful');
+      const user = JSON.parse(userData);
+      localStorage.setItem('user', JSON.stringify(user)); // Save user to localStorage
+      setUser(user);
       return true;
     }
-
     throw new Error('Invalid username or password');
   };
 
@@ -36,15 +46,38 @@ export const UserProvider = ({ children }) => {
 
     const userData = { name, username, email, password };
     localStorage.setItem(username, JSON.stringify(userData));
+    localStorage.setItem('user', JSON.stringify(userData)); // Save user to localStorage
     setUser(userData);
   };
 
   const signOut = () => {
+    localStorage.removeItem('user'); // Remove user from localStorage on sign out
     setUser(null);
   };
 
+  const authenticateWallet = async () => {
+    if (window.ethereum) {
+      const web3 = new Web3(window.ethereum);
+
+      try {
+        await window.ethereum.enable();
+        const accounts = await web3.eth.getAccounts();
+        const address = accounts[0];
+        const userData = { address, web3 };
+        localStorage.setItem('user', JSON.stringify(userData)); // Save user to localStorage
+        setUser(userData);
+        return true;
+      } catch (error) {
+        console.error('Error authenticating wallet:', error);
+        throw new Error('Failed to authenticate wallet');
+      }
+    } else {
+      throw new Error('No Ethereum wallet detected');
+    }
+  };
+
   return (
-    <UserContext.Provider value={{ user, signIn, signUp, signOut }}>
+    <UserContext.Provider value={{ user, signIn, signUp, signOut, authenticateWallet }}>
       {children}
     </UserContext.Provider>
   );

--- a/src/ValidationContract.json
+++ b/src/ValidationContract.json
@@ -1,0 +1,423 @@
+{
+  "contractName": "ValidationContract",
+  "abi": [
+    {
+      "inputs": [],
+      "name": "validateUser",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    }
+  ],
+  "metadata": "{\"compiler\":{\"version\":\"0.8.13+commit.abaa5c0e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"name\":\"validateUser\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"project:/contracts/validation.sol\":\"ValidationContract\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"project:/contracts/validation.sol\":{\"keccak256\":\"0xb2653bc37de60b6059e0c2aec1da3a9adee035cfa91bc518c8269aff02b286c7\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ac7e607cf221644af1d883ae72e4615a95fa9109861c94dbc50a8b88559d5edd\",\"dweb:/ipfs/QmPrEnxFwxEMXs5qh4fCh2cTvNPEKMGNBiKvYayp13D7MK\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b5060b88061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063efcbb0f014602d575b600080fd5b60336047565b604051603e91906069565b60405180910390f35b60006001905090565b60008115159050919050565b6063816050565b82525050565b6000602082019050607c6000830184605c565b9291505056fea26469706673582212206dc55a4d0d8ae6dd67536ac412d18b4ccac07459b5a635a89b89d2d8f752cdba64736f6c634300080d0033",
+  "deployedBytecode": "0x6080604052348015600f57600080fd5b506004361060285760003560e01c8063efcbb0f014602d575b600080fd5b60336047565b604051603e91906069565b60405180910390f35b60006001905090565b60008115159050919050565b6063816050565b82525050565b6000602082019050607c6000830184605c565b9291505056fea26469706673582212206dc55a4d0d8ae6dd67536ac412d18b4ccac07459b5a635a89b89d2d8f752cdba64736f6c634300080d0033",
+  "immutableReferences": {},
+  "generatedSources": [],
+  "deployedGeneratedSources": [
+    {
+      "ast": {
+        "nodeType": "YulBlock",
+        "src": "0:431:1",
+        "statements": [
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "49:48:1",
+              "statements": [
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "59:32:1",
+                  "value": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "value",
+                            "nodeType": "YulIdentifier",
+                            "src": "84:5:1"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "iszero",
+                          "nodeType": "YulIdentifier",
+                          "src": "77:6:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "77:13:1"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "iszero",
+                      "nodeType": "YulIdentifier",
+                      "src": "70:6:1"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "70:21:1"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "cleaned",
+                      "nodeType": "YulIdentifier",
+                      "src": "59:7:1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "cleanup_t_bool",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "value",
+                "nodeType": "YulTypedName",
+                "src": "31:5:1",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "cleaned",
+                "nodeType": "YulTypedName",
+                "src": "41:7:1",
+                "type": ""
+              }
+            ],
+            "src": "7:90:1"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "162:50:1",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "pos",
+                        "nodeType": "YulIdentifier",
+                        "src": "179:3:1"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "name": "value",
+                            "nodeType": "YulIdentifier",
+                            "src": "199:5:1"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "cleanup_t_bool",
+                          "nodeType": "YulIdentifier",
+                          "src": "184:14:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "184:21:1"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "172:6:1"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "172:34:1"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "172:34:1"
+                }
+              ]
+            },
+            "name": "abi_encode_t_bool_to_t_bool_fromStack",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "value",
+                "nodeType": "YulTypedName",
+                "src": "150:5:1",
+                "type": ""
+              },
+              {
+                "name": "pos",
+                "nodeType": "YulTypedName",
+                "src": "157:3:1",
+                "type": ""
+              }
+            ],
+            "src": "103:109:1"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "310:118:1",
+              "statements": [
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "320:26:1",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "332:9:1"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "343:2:1",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "328:3:1"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "328:18:1"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "tail",
+                      "nodeType": "YulIdentifier",
+                      "src": "320:4:1"
+                    }
+                  ]
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "value0",
+                        "nodeType": "YulIdentifier",
+                        "src": "394:6:1"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "407:9:1"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "418:1:1",
+                            "type": "",
+                            "value": "0"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "403:3:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "403:17:1"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "abi_encode_t_bool_to_t_bool_fromStack",
+                      "nodeType": "YulIdentifier",
+                      "src": "356:37:1"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "356:65:1"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "356:65:1"
+                }
+              ]
+            },
+            "name": "abi_encode_tuple_t_bool__to_t_bool__fromStack_reversed",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "282:9:1",
+                "type": ""
+              },
+              {
+                "name": "value0",
+                "nodeType": "YulTypedName",
+                "src": "294:6:1",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "tail",
+                "nodeType": "YulTypedName",
+                "src": "305:4:1",
+                "type": ""
+              }
+            ],
+            "src": "218:210:1"
+          }
+        ]
+      },
+      "contents": "{\n\n    function cleanup_t_bool(value) -> cleaned {\n        cleaned := iszero(iszero(value))\n    }\n\n    function abi_encode_t_bool_to_t_bool_fromStack(value, pos) {\n        mstore(pos, cleanup_t_bool(value))\n    }\n\n    function abi_encode_tuple_t_bool__to_t_bool__fromStack_reversed(headStart , value0) -> tail {\n        tail := add(headStart, 32)\n\n        abi_encode_t_bool_to_t_bool_fromStack(value0,  add(headStart, 0))\n\n    }\n\n}\n",
+      "id": 1,
+      "language": "Yul",
+      "name": "#utility.yul"
+    }
+  ],
+  "sourceMap": "58:115:0:-:0;;;;;;;;;;;;;;;;;;;",
+  "deployedSourceMap": "58:115:0:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;92:79;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;;137:4;160;153:11;;92:79;:::o;7:90:1:-;41:7;84:5;77:13;70:21;59:32;;7:90;;;:::o;103:109::-;184:21;199:5;184:21;:::i;:::-;179:3;172:34;103:109;;:::o;218:210::-;305:4;343:2;332:9;328:18;320:26;;356:65;418:1;407:9;403:17;394:6;356:65;:::i;:::-;218:210;;;;:::o",
+  "source": "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.13;\n\ncontract ValidationContract {\n    function validateUser() public pure returns (bool) {\n        return true;\n    }\n}\n",
+  "sourcePath": "/Users/yanlin/Desktop/variable_lending_pool/contracts/validation.sol",
+  "ast": {
+    "absolutePath": "project:/contracts/validation.sol",
+    "exportedSymbols": {
+      "ValidationContract": [
+        10
+      ]
+    },
+    "id": 11,
+    "license": "MIT",
+    "nodeType": "SourceUnit",
+    "nodes": [
+      {
+        "id": 1,
+        "literals": [
+          "solidity",
+          "^",
+          "0.8",
+          ".13"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "32:24:0"
+      },
+      {
+        "abstract": false,
+        "baseContracts": [],
+        "canonicalName": "ValidationContract",
+        "contractDependencies": [],
+        "contractKind": "contract",
+        "fullyImplemented": true,
+        "id": 10,
+        "linearizedBaseContracts": [
+          10
+        ],
+        "name": "ValidationContract",
+        "nameLocation": "67:18:0",
+        "nodeType": "ContractDefinition",
+        "nodes": [
+          {
+            "body": {
+              "id": 8,
+              "nodeType": "Block",
+              "src": "143:28:0",
+              "statements": [
+                {
+                  "expression": {
+                    "hexValue": "74727565",
+                    "id": 6,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "kind": "bool",
+                    "lValueRequested": false,
+                    "nodeType": "Literal",
+                    "src": "160:4:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    },
+                    "value": "true"
+                  },
+                  "functionReturnParameters": 5,
+                  "id": 7,
+                  "nodeType": "Return",
+                  "src": "153:11:0"
+                }
+              ]
+            },
+            "functionSelector": "efcbb0f0",
+            "id": 9,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "validateUser",
+            "nameLocation": "101:12:0",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 2,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "113:2:0"
+            },
+            "returnParameters": {
+              "id": 5,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 4,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nameLocation": "-1:-1:-1",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 9,
+                  "src": "137:4:0",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  },
+                  "typeName": {
+                    "id": 3,
+                    "name": "bool",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "137:4:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "136:6:0"
+            },
+            "scope": 10,
+            "src": "92:79:0",
+            "stateMutability": "pure",
+            "virtual": false,
+            "visibility": "public"
+          }
+        ],
+        "scope": 11,
+        "src": "58:115:0",
+        "usedErrors": []
+      }
+    ],
+    "src": "32:142:0"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.8.13+commit.abaa5c0e.Emscripten.clang"
+  },
+  "networks": {},
+  "schemaVersion": "3.4.16",
+  "updatedAt": "2023-12-23T02:06:54.624Z",
+  "devdoc": {
+    "kind": "dev",
+    "methods": {},
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {},
+    "version": 1
+  }
+}


### PR DESCRIPTION
Sign in/up page with working authentication and redirection which depends on additional contract for wallet authentication (mocked with validation.sol for now which always returns True) -- I think/hope

1. New user creates account (sign up) after connecting Ethereum wallet (right now, it uses validation.sol, afterwards, it should connect to Bowen's contract)
3. Existing user do not need to authenticate wallet again when signing-in